### PR TITLE
[docs] SOFA Robotics without Emio Labs

### DIFF
--- a/docs/Developers/sofa-robotics-without-emio-labs.md
+++ b/docs/Developers/sofa-robotics-without-emio-labs.md
@@ -1,0 +1,107 @@
+---
+title: SOFA Robotics w/o Emio Labs
+sidebar_position: 1
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# SOFA Robotics without Emio Labs
+
+This guide provides instructions for using SOFA Robotics independently of the Emio Labs application.
+
+:::warning
+To use SOFA Robotics independently of Emio Labs, you first need to download the appropriate package for your operating system. This package may come as an installer (`.deb` for Linux, `.msi` for Windows, or `.dmg` for MacOS) or as a compressed archive (`.zip`). It is important to note that portable formats, which run from a temporary directory, are not supported. Ensure you extract or install the package to a permanent location on your system before proceeding.
+:::
+
+## Locate the SOFA Robotics Directory and Executable
+
+Begin by locating the SOFA Robotics directory and executable file, typically named `runSofa` (or `runSofa.exe` on Windows). Follow the instructions below depending on your chosen format: 
+
+<Tabs className="unique-tabs">
+  <TabItem value="installer" label="Installer" default>
+      1. Locate the directory where you installed the Emio Labs application. We will refer to this directory as `PATH_TO_EMIO_LABS`. 
+      2. Within this directory, you will find the SOFA Robotics directory at `PATH_TO_EMIO_LABS/assets/resources/sofa`. 
+      3. Inside this directory, you will find the `bin` subdirectory, which contains the executable file required to run the software. This executable is essential for launching SOFA Robotics independently.
+  </TabItem>
+  <TabItem value="archive" label="Compressed Archive">
+      1. Extract the compressed archive to your chosen location (referred to as `PATH_TO_EMIO_LABS`).
+      2. Within this directory, you will find the SOFA Robotics directory at `PATH_TO_EMIO_LABS/assets/resources/sofa`. 
+      3. Inside this directory, you will find the `bin` subdirectory, which contains the executable file required to run the software. This executable is essential for launching SOFA Robotics independently.
+  </TabItem>
+</Tabs>
+
+## Setup the Environment Variables
+
+In the previous section, you located the path to the SOFA Robotics directory. 
+We will refer to this path as `PATH_TO_SOFA_ROBOTICS_DIR` throughout this guide.
+
+To run the software, you need to configure your environment by adding specific paths to your `PATH` and `PYTHONPATH`, along with other required environment variables. 
+
+The steps below will help you set up these variables temporarily. Note that these changes will only last for the duration of your terminal session. To avoid repeating these steps every time you run SOFA, consider creating a script to automate the process. However, we recommend against setting these variables permanently to maintain a clean environment.
+
+Open a terminal and run the commands for your operating system as outlined below.
+
+<Tabs className="unique-tabs">
+  <TabItem value="linux" label="Linux" default>
+        ```bash
+        export SOFA_ROOT=PATH_TO_SOFA_ROBOTICS_DIR
+        export PATH=$PATH:$SOFA_ROOT\bin
+        export PYTHONHOME=$SOFA_ROOT\bin\python
+        export PYTHONPATH=$SOFA_ROOT\bin\python\lib\python3.10\site-packages
+        export PYTHONPATH=$PYTHONPATH:$SOFA_ROOT\plugins\SofaPython3\lib\python3\site-packages
+        ```
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+        #### Using Powershell:
+
+        ```powershell
+        $env.SOFA_ROOT=PATH_TO_SOFA_ROBOTICS_DIR
+        $env.PATH+=$env.SOFA_ROOT\bin
+        $env.PYTHONHOME=$env.SOFA_ROOT\bin\python
+        $env.PYTHONPATH=$env.SOFA_ROOT\bin\python\Lib\site-packages
+        $env.PYTHONPATH+=$env.SOFA_ROOT\plugins\SofaPython3\lib\python3\site-packages
+        ```
+
+        #### Using Command Prompt:
+
+        ```bash
+        set SOFA_ROOT=PATH_TO_SOFA_ROBOTICS_DIR
+        set PATH=$PATH:$SOFA_ROOT\bin
+        set PYTHONHOME=$SOFA_ROOT\bin\python
+        set PYTHONPATH=$SOFA_ROOT\bin\python\Lib\site-packages
+        set PYTHONPATH=$PYTHONPATH:$SOFA_ROOT\plugins\SofaPython3\lib\python3\site-packages
+        ```
+  </TabItem>
+  <TabItem value="macos" label="MacOS">
+        ```bash
+        export SOFA_ROOT=PATH_TO_SOFA_ROBOTICS_DIR
+        export PATH=$PATH:$SOFA_ROOT\bin
+        ```
+  </TabItem>
+</Tabs>
+
+## Launch the Software
+
+In the same terminal, try the following command: `runSofa -l SofaPython3,SofaImGui`.
+This should run the SOFA Robotics with a default simulation (press the play button). To run your own simulation:
+
+
+
+<Tabs className="unique-tabs">
+  <TabItem value="linux" label="Linux" default>
+      ```bash
+      runSofa -l SofaPython3,SofaImGui your_scene.py
+      ```
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+      ```bash
+      runSofa.exe -l SofaPython3,SofaImGui your_scene.py
+      ```
+  </TabItem>
+  <TabItem value="macos" label="MacOS">
+      ```bash
+      runSofa -l SofaPython3,SofaImGui your_scene.py
+      ```
+  </TabItem>
+</Tabs>

--- a/docs/Users/EmioLabs/create-your-lab.md
+++ b/docs/Users/EmioLabs/create-your-lab.md
@@ -40,7 +40,7 @@ The content of the application is set in the file `assets/labs/labsConfig.json`.
 
 The order of the labs in the application will match the order in the `labsConfig.json` file. For example:   
 
-```json
+```json title="/assets/labs/labsConfig.json"
 {
     "labs": [
         {

--- a/docs/Users/EmioLabs/emio-labs-user-manual.md
+++ b/docs/Users/EmioLabs/emio-labs-user-manual.md
@@ -5,6 +5,8 @@ sidebar_position: 3
 
 import emiolabs_overview from './img/emio-labs-overview.png';
 import exercise_overview from './img/exercise.png';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # App User Manual
 
@@ -28,40 +30,40 @@ Ensure your system meets the following minimum requirements:
 
 Visit our [website and download](https://compliance-robotics.com/compliance-lab/) the **Emio Labs** application for free. After completing a form, you'll receive an email with download links. Choose the version that matches your operating system. Each version comes in three formats: an installer, a portable, or a `.zip` file containing the binaries.
 
+<Tabs className="unique-tabs">
+  <TabItem value="linux" label="Linux" default>
+       :::warning[requirements]
+       To use the portable `.AppImage`, install libfuse2: `sudo apt install libfuse2`
+       ::: 
+       1. **Installer.** If you have downloaded an installer `.deb`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
+       2. **Portable.** If you have downloaded a portable `.AppImage`, untar the file, the **Emio Labs** application is the resulting executable file.   
+       3. **Binaries.** If you have downloaded the `.zip` file, first, unzip the directory. The **Emio Labs** application is then located at the root of the directory. 
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+       :::warning[requirements]
+       All formats require [Microsoft Visual C++ 2022 Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) to be installed.
+       :::
+
+       1. **Installer.** If you have downloaded an installer `.msi`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
+       2. **Portable.** If you have downloaded a portable `.exe`, the **Emio Labs** application is this executable file. Note that the application may take a while to open, as the software needs to install itself in a temporary directory before launching.   
+       3. **Binaries.** If you have downloaded the `.zip` file, first, unzip the directory. The **Emio Labs** application is then located at the root of the directory. 
+
+  </TabItem>
+  <TabItem value="macos" label="MacOS">
+       :::warning[requirements]
+       Install [Python 3.10](https://www.python.org/downloads/release/python-31011/) for MacOS from [python.org](http://python.org/). Download the file `requirements.txt` and install the required Python modules by running `python -m pip install -r requirements.txt`.
+       :::
+
+       1. **Installer.** If you have downloaded an installer `.dmg`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
+       2. **Portable.** If you have downloaded the `.zip`, double-click the file to create a `.app` file. To launch the **Emio Labs** application, simply click this new file. 
+  </TabItem>
+</Tabs>
+
 Once installed, try the Emio Labs application. 
 
 :::tip[important]
 A directory <code>~/emio-labs</code> containing all the assets (labs, python scripts, meshes, etc.) is created in your Home directory after the first run of the application. The application uses the files of this directory. If you make modifications and want to reset the directory to its original state, simply delete or remove it from your Home directory, then rerun the application.
 :::
-
-### Installation on Linux
-
-:::note[requirements]
-To use the portable `.AppImage`, install libfuse2: `sudo apt install libfuse2`
-::: 
-
-1. **Installer.** If you have downloaded an installer `.deb`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
-2. **Portable.** If you have downloaded a portable `.AppImage`, untar the file, the **Emio Labs** application is the resulting executable file.   
-3. **Binaries.** If you have downloaded the `.zip` file, first, unzip the directory. The **Emio Labs** application is then located at the root of the directory. 
-
-### Installation on Windows
-
-:::note[requirements]
-All formats require [Microsoft Visual C++ 2022 Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) to be installed.
-:::
-
-1. **Installer.** If you have downloaded an installer `.msi`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
-2. **Portable.** If you have downloaded a portable `.exe`, the **Emio Labs** application is this executable file. Note that the application may take a while to open, as the software needs to install itself in a temporary directory before launching.   
-3. **Binaries.** If you have downloaded the `.zip` file, first, unzip the directory. The **Emio Labs** application is then located at the root of the directory. 
-
-### Installation on MacOS
-
-:::note[requirements]
-Install [Python 3.10](https://www.python.org/downloads/release/python-31011/) for MacOS from [python.org](http://python.org/). Download the file `requirements.txt` and install the required Python modules by running `python -m pip install -r requirements.txt`.
-:::
-
-1. **Installer.** If you have downloaded an installer `.dmg`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
-2. **Portable.** If you have downloaded the `.zip`, double-click the file to create a `.app` file. To launch the **Emio Labs** application, simply click this new file. 
 
 ## Application Overview
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -47,7 +47,8 @@ const config: Config = {
             keywords: ['note', 'tip', 'info', 'warning', 'danger', 'verified'],
             extendDefaults: true,
           },
-          sidebarPath: './sidebars.ts'
+          sidebarPath: './sidebars.ts',
+          sidebarCollapsed: false
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -126,6 +127,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['powershell','bash','markdown'],
     },
   } satisfies Preset.ThemeConfig,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14719,6 +14719,7 @@
       "version": "2.17.3",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
       "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/section-matter": {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -53,6 +53,28 @@ img {
   margin-right: auto;
 }
 
+.unique-tabs .tabs__item {
+  margin-right: 8px;
+  line-height: 16px;
+}
+
+.unique-tabs .tabs__item--active {
+  color: #fff;
+  border-radius: var(--ifm-global-radius);
+  background-color: var(--ifm-tabs-color-active);
+  border: 0
+}
+
+.tabs-container {
+  border-left: var(--ifm-alert-border-left-width) solid
+  var(--ifm-blockquote-border-color);
+  box-shadow: var(--ifm-blockquote-shadow);
+  color: var(--ifm-blockquote-color);
+  font-size: var(--ifm-blockquote-font-size);
+  margin: 0 0 var(--ifm-spacing-vertical);
+  padding: var(--ifm-blockquote-padding-vertical)
+    var(--ifm-blockquote-padding-horizontal);
+}
 
 
 


### PR DESCRIPTION
In this PR:

- adds a documentation to use SOFA Robotics independently of Emio Labs
- in the left sidebar menu, open all collapsible headers by default
- now uses tabs, with a custom css