### PR TITLE
[Emio & Emio Labs] Instructions on linux for serial ports permission

### DIFF
--- a/docs/Users/Emio/getting-started-with-emio.md
+++ b/docs/Users/Emio/getting-started-with-emio.md
@@ -53,22 +53,6 @@ Emio features two distinct configurations, as shown in the images below:
     </div>
 </div>
 
-## Connecting Emio to Your Computer
-You will find a USB cable in the drawer to connect the robot to your computer. The robot also has a power supply and a switch.
-To connect Emio to your computer:
-1. Plug the USB cable into the USB port of Emio (see Figure 2),
-2. Connect the other end of the USB cable to your computer,
-3. Plug the power supply into the power port of Emio (see Figure 3),
-4. Turn on the switch to power the robot (see Figure 3).
-
-<div style={{display: "flex"}}>
-    <div>
-        <img className="centered" src={emio_connections} width="30%" alt="The connection panel on the side of Emio"/>
-        <figcaption>(1) USB connection. (2) Power connection. (3) Switch to power the robot.</figcaption>
-    </div>
-</div>
-
-
 ## Attaching Legs to Motors
 Each motor is equipped with a drum and a cap for connecting a leg.
 
@@ -98,8 +82,63 @@ To attach a leg to a motor:
 </div>
 
 :::note
-Throughout the lab sessions, you will be instructed to configure Emio into specific setups. Simply follow the 
+When using [Emio Labs](../../../Users/EmioLabs/), throughout the lab sessions, you will be instructed to configure Emio into specific setups. Simply follow the 
 provided instructions by clicking on *Set up Emio*. We use colors to refer to the legs and connectors, and numbers to identify the motors.
+:::
+
+## Connecting Emio to Your Computer
+
+<Tabs className="unique-tabs" groupId="operating-systems">
+  <TabItem value="linux" label="Linux" default>
+
+     On Linux, serial ports require specific permissions to be accessed. By default, only the `root` user can access `/dev/ttyUSB*`. Here are two solutions to grant access to serial ports and pilot the real robot:
+
+          <Tabs className="unique-tabs" groupId="serial-ports">
+               <TabItem value="temporary" label="Temporary" default>
+                    Run the following command to grant read/write permissions:
+                    ```bash
+                    sudo chmod 777 /dev/ttyUSB0
+                    ```
+                    Note: Replace `ttyUSB0` with the actual port name. You can find it by running `ls /dev/ttyUSB*` or by using SOFA Robotics. This change will revert after reboot or disconnect.
+               </TabItem>
+               <TabItem value="permanent" label="Permanent" default>
+                    Add your user to the `dialout` group to access serial devices without root privileges:
+                    ```bash
+                    sudo usermod -aG dialout $USER
+                    ```
+                    Then log out and log back in (or reboot) for the group changes to take effect. This is the recommended approach.  
+               </TabItem>
+          </Tabs>
+
+  </TabItem>
+  <TabItem value="windows" label="Windows" default>
+
+       Depending on your version of Windows, you may need to install the [FTDI drivers](https://ftdichip.com/drivers/vcp-drivers/) to pilot the robot. This is typically necessary if, upon connecting the robot to your computer, you encounter the following error message:  
+       `[ERROR] No serial port found with manufacturer = FTDI`.  
+       Installing the drivers should resolve this issue.
+  </TabItem>
+</Tabs>
+
+You will find a USB cable in the drawer to connect the robot to your computer. The robot also has a power supply and a switch.
+To connect Emio to your computer:
+1. Plug the USB cable into the USB port of Emio,
+2. Connect the other end of the USB cable to your computer,
+3. Plug the power supply into the power port of Emio,
+4. Turn on the switch to power the robot.
+
+<div style={{display: "flex"}}>
+    <div>
+        <img className="centered" src={emio_connections} width="30%" alt="The connection panel on the side of Emio"/>
+        <figcaption>(1) USB connection. (2) Power connection. (3) Switch to power the robot.</figcaption>
+    </div>
+</div>
+
+:::note
+To pilot Emio, you have two options: 
+1. You can use [Emio Labs](../../../Users/EmioLabs/), which provides an intuitive interface to launch SOFA Robotics and run simulations to solve Emio's inverse kinematics and control the robot's end-effector.
+2. Or you can use the [Emio API](../../../Developers/emio-api/), which allows you to pilot the motors of Emio programmatically using Python.  
+
+You can find more information about these two options in the following sections.
 :::
 
 ## Calibrating the Camera

--- a/docs/Users/EmioLabs/emio-labs-user-manual.md
+++ b/docs/Users/EmioLabs/emio-labs-user-manual.md
@@ -38,21 +38,17 @@ Ensure your system meets the following minimum requirements:
 <Tabs className="unique-tabs" groupId="operating-systems">
   <TabItem value="linux" label="Linux" default>
        :::important[requirements]
-       - To use the portable `.AppImage`, install libfuse2: `sudo apt install libfuse2`
-
-       - When trying to connect the real robot, if you get a `[Errno 13] Permission denied: '/dev/ttyUSB0'` message. Run the following command in terminal: `sudo chmod 777 /dev/ttyUSB0`. Make sure that the name of the USB port matches the one from the error message.
+       - To use the portable format `.AppImage`, install libfuse2: `sudo apt install libfuse2`  
        ::: 
+
        1. **Installer.** If you have downloaded an installer `.deb`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
        2. **Portable.** If you have downloaded a portable `.AppImage`, untar the file, the **Emio Labs** application is the resulting executable file.   
        3. **Binaries.** If you have downloaded the `.zip` file, first, unzip the directory. The **Emio Labs** application is then located at the root of the directory. 
+
   </TabItem>
   <TabItem value="windows" label="Windows">
        :::important[requirements]
        - All formats require [Microsoft Visual C++ 2022 Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) to be installed.
-
-       - Depending on your version of Windows, you may need to install the [FTDI drivers](https://ftdichip.com/drivers/vcp-drivers/) to pilot the robot. This is typically necessary if, upon connecting the robot to your computer, you encounter the following error message:  
-       `[ERROR] No serial port found with manufacturer = FTDI`.  
-       Installing the drivers should resolve this issue.
        :::   
 
        1. **Installer.** If you have downloaded an installer `.msi`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
@@ -70,9 +66,11 @@ Ensure your system meets the following minimum requirements:
        1. **Installer.** If you have downloaded an installer `.dmg`, run it and follow the on-screen instructions.
        2. **Portable.** If you have downloaded the `.zip`, double-click the file to create a `.app` file.
 
-       To launch Emio Labs on MacOS, please refer to the [section below](#running-emio-labs-on-macos) 
+       To launch Emio Labs on MacOS, please refer to the [section below](#running-emio-labs-on-macos). 
   </TabItem>
 </Tabs>
+
+Check [Getting Starting with Emio](../../Users/Emio/getting-started-with-emio.md) for instructions on how to connect Emio to your computer and pilot the real robot.
 
 ### Running Emio Labs on MacOS
 :::warning

--- a/versioned_docs/version-v25.06/Users/Emio/getting-started-with-emio.md
+++ b/versioned_docs/version-v25.06/Users/Emio/getting-started-with-emio.md
@@ -3,6 +3,9 @@ title: Getting Started With Emio
 sidebar_position: 1
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 import accessories from './img/accessories.jpg';
 import emio_drawer_camera from './img/emio-drawer-camera.png';
 import emio_motors from './img/emio-motors.png';
@@ -17,14 +20,14 @@ import motor_cap4 from './img/motor-cap4.png';
 Emio is a parallel deformable robot developed by [Compliance Robotics](https://compliance-robotics.com/). 
 It features a structure composed of four servo motor-actuated deformable legs connected together. 
 
+## Discovering Emio
+
 The robot comes equipped with a depth camera and a set of accessories, including multiple deformable legs and connectors, all stored in a dedicated drawer.
 
 Emio features two distinct configurations, as shown in the images below:
 
 1. **Extended Configuration**: In this setup, the legs point downward, enabling it to perform tasks such as pick-and-place.
 2. **Compact Configuration**: Here, the legs are oriented upward, facilitating easier interaction with the robot.
-
-
 
 <div style={{display: "flex"}}>
     <div>
@@ -45,22 +48,6 @@ Emio features two distinct configurations, as shown in the images below:
     </div>
 </div>
 
-## Connecting Emio to Your Computer
-You will find a USB cable in the drawer to connect the robot to your computer. The robot also has a power supply and a switch.
-To connect Emio to your computer:
-1. Plug the USB cable into the USB port of Emio (see Figure 2),
-2. Connect the other end of the USB cable to your computer,
-3. Plug the power supply into the power port of Emio (see Figure 3),
-4. Turn on the switch to power the robot (see Figure 3).
-
-<div style={{display: "flex"}}>
-    <div>
-        <img className="centered" src={emio_connections} width="50%"/>
-        <figcaption>(1) USB connection. (2) Power connection. (3) Switch to power the robot.</figcaption>
-    </div>
-</div>
-
-
 ## Attaching Legs to Motors
 Each motor is equipped with a drum and a cap for connecting a leg.
 
@@ -72,29 +59,79 @@ To attach a leg to a motor:
 
 <div style={{display: "flex"}}>
     <div>
-        <img className="centered" src={motor_cap1} width="90%"/>
+        <img className="centered" src={motor_cap1} width="90%" alt="One Emio motor with the zero position marker pointing upward"/>
         <figcaption>(1) Motor's zero position (orange marker pointing upward) </figcaption>
     </div>
     <div>
-        <img className="centered" src={motor_cap2} width="90%"/>
+        <img className="centered" src={motor_cap2} width="90%" alt="Emio motor with the cap rotated and the leg attached to it and pointing downward"/>
         <figcaption>(2) Rotate the cap until the leg can be attached </figcaption>
     </div>
     <div>
-        <img className="centered" src={motor_cap3} width="90%"/>
+        <img className="centered" src={motor_cap3} width="90%" alt="Emio motor with the cap rotated back to lock in the leg"/>
         <figcaption>(3) Once the leg is in place, rotate the cap again to lock it </figcaption>
     </div>
     <div>
-        <img className="centered" src={motor_cap4} width="90%"/>
+        <img className="centered" src={motor_cap4} width="90%" alt="Another example of position for the leg, pointing upward instead"/>
         <figcaption>(4) The leg can be adjusted to different positions </figcaption>
     </div>
 </div>
 
-                   
-<!-- | ![](assets/data/images/legs/blueleg-clockwiseup.png)    | ![](assets/data/images/legs/blueleg-counterclockwiseup.png) | ![](assets/data/images/legs/blueleg-clockwisedown.png)   | ![](assets/data/images/legs/blueleg-counterclockwisedown.png)   | 
-|:--------------------------------------------------:|:------------------------------------------------------:|:---------------------------------------------------:|:----------------------------------------------------------:|
-|         **(1) The blue leg clockwise up**          |       **(2) The blue leg counter clockwise up**        |         **(3) The blue leg clockwise down**         |        **(4) The blue leg counter clockwise down**         | -->
+:::note
+When using [Emio Labs](../../../Users/EmioLabs/), throughout the lab sessions, you will be instructed to configure Emio into specific setups. Simply follow the 
+provided instructions by clicking on *Set up Emio*. We use colors to refer to the legs and connectors, and numbers to identify the motors.
+:::
+
+## Connecting Emio to Your Computer
+
+<Tabs className="unique-tabs" groupId="operating-systems">
+  <TabItem value="linux" label="Linux" default>
+
+     On Linux, serial ports require specific permissions to be accessed. By default, only the `root` user can access `/dev/ttyUSB*`. Here are two solutions to grant access to serial ports and pilot the real robot:
+
+          <Tabs className="unique-tabs" groupId="serial-ports">
+               <TabItem value="temporary" label="Temporary" default>
+                    Run the following command to grant read/write permissions:
+                    ```bash
+                    sudo chmod 777 /dev/ttyUSB0
+                    ```
+                    Note: Replace `ttyUSB0` with the actual port name. You can find it by running `ls /dev/ttyUSB*` or by using SOFA Robotics. This change will revert after reboot or disconnect.
+               </TabItem>
+               <TabItem value="permanent" label="Permanent" default>
+                    Add your user to the `dialout` group to access serial devices without root privileges:
+                    ```bash
+                    sudo usermod -aG dialout $USER
+                    ```
+                    Then log out and log back in (or reboot) for the group changes to take effect. This is the recommended approach.  
+               </TabItem>
+          </Tabs>
+
+  </TabItem>
+  <TabItem value="windows" label="Windows" default>
+
+       Depending on your version of Windows, you may need to install the [FTDI drivers](https://ftdichip.com/drivers/vcp-drivers/) to pilot the robot. This is typically necessary if, upon connecting the robot to your computer, you encounter the following error message:  
+       `[ERROR] No serial port found with manufacturer = FTDI`.  
+       Installing the drivers should resolve this issue.
+  </TabItem>
+</Tabs>
+
+You will find a USB cable in the drawer to connect the robot to your computer. The robot also has a power supply and a switch.
+To connect Emio to your computer:
+1. Plug the USB cable into the USB port of Emio,
+2. Connect the other end of the USB cable to your computer,
+3. Plug the power supply into the power port of Emio,
+4. Turn on the switch to power the robot.
+
+<div style={{display: "flex"}}>
+    <div>
+        <img className="centered" src={emio_connections} width="30%" alt="The connection panel on the side of Emio"/>
+        <figcaption>(1) USB connection. (2) Power connection. (3) Switch to power the robot.</figcaption>
+    </div>
+</div>
 
 :::note
-Throughout the lab sessions, you will be instructed to configure Emio into specific setups. Simply follow the 
-provided instructions by clicking on *Set up Emio*. We use colors to refer to the legs and connectors, and numbers to identify the motors.
+To pilot Emio, you have two options: 
+1. You can use [Emio Labs](../../../Users/EmioLabs/), which provides an intuitive interface to launch SOFA Robotics and run simulations to solve Emio's inverse kinematics and control the robot's end-effector.
+2. Or you can use the [Emio API](../../../Developers/emio-api/), which allows you to pilot the motors of Emio programmatically using Python.  
+
+You can find more information about these two options in the following sections.
 :::

--- a/versioned_docs/version-v25.06/Users/EmioLabs/emio-labs-user-manual.md
+++ b/versioned_docs/version-v25.06/Users/EmioLabs/emio-labs-user-manual.md
@@ -58,6 +58,8 @@ Ensure your system meets the following minimum requirements:
 
        1. **Installer.** If you have downloaded an installer `.dmg`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
        2. **Portable.** If you have downloaded the `.zip`, double-click the file to create a `.app` file. To launch the **Emio Labs** application, simply click this new file. 
+       
+       To launch Emio Labs on MacOS, please refer to the [section below](#running-emio-labs-on-macos). 
   </TabItem>
 </Tabs>
 

--- a/versioned_docs/version-v25.06/Users/EmioLabs/emio-labs-user-manual.md
+++ b/versioned_docs/version-v25.06/Users/EmioLabs/emio-labs-user-manual.md
@@ -34,8 +34,6 @@ Ensure your system meets the following minimum requirements:
   <TabItem value="linux" label="Linux" default>
        :::important[requirements]
        - To use the portable `.AppImage`, install libfuse2: `sudo apt install libfuse2`
-
-       - When trying to connect the real robot, if you get a `[Errno 13] Permission denied: '/dev/ttyUSB0'` message. Run the following command in terminal: `sudo chmod 777 /dev/ttyUSB0`. Make sure that the name of the USB port matches the one from the error message.
        ::: 
        1. **Installer.** If you have downloaded an installer `.deb`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
        2. **Portable.** If you have downloaded a portable `.AppImage`, untar the file, the **Emio Labs** application is the resulting executable file.   
@@ -44,10 +42,6 @@ Ensure your system meets the following minimum requirements:
   <TabItem value="windows" label="Windows">
        :::important[requirements]
        - All formats require [Microsoft Visual C++ 2022 Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) to be installed.
-
-       - Depending on your version of Windows, you may need to install the [FTDI drivers](https://ftdichip.com/drivers/vcp-drivers/) to pilot the robot. This is typically necessary if, upon connecting the robot to your computer, you encounter the following error message:  
-       `[ERROR] No serial port found with manufacturer = FTDI`.  
-       Installing the drivers should resolve this issue.
        :::   
 
        1. **Installer.** If you have downloaded an installer `.msi`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
@@ -67,7 +61,7 @@ Ensure your system meets the following minimum requirements:
   </TabItem>
 </Tabs>
 
-Once installed, try the Emio Labs application. 
+Once installed, try the Emio Labs application. Check [Getting Starting with Emio](../../Users/Emio/getting-started-with-emio.md) for instructions on how to connect Emio to your computer and pilot the real robot.
 
 
 :::tip[important]

--- a/versioned_docs/version-v25.12/Users/Emio/getting-started-with-emio.md
+++ b/versioned_docs/version-v25.12/Users/Emio/getting-started-with-emio.md
@@ -53,21 +53,6 @@ Emio features two distinct configurations, as shown in the images below:
     </div>
 </div>
 
-## Connecting Emio to Your Computer
-You will find a USB cable in the drawer to connect the robot to your computer. The robot also has a power supply and a switch.
-To connect Emio to your computer:
-1. Plug the USB cable into the USB port of Emio (see Figure 2),
-2. Connect the other end of the USB cable to your computer,
-3. Plug the power supply into the power port of Emio (see Figure 3),
-4. Turn on the switch to power the robot (see Figure 3).
-
-<div style={{display: "flex"}}>
-    <div>
-        <img className="centered" src={emio_connections} width="30%" alt="The connection panel on the side of Emio"/>
-        <figcaption>(1) USB connection. (2) Power connection. (3) Switch to power the robot.</figcaption>
-    </div>
-</div>
-
 
 ## Attaching Legs to Motors
 Each motor is equipped with a drum and a cap for connecting a leg.
@@ -98,8 +83,63 @@ To attach a leg to a motor:
 </div>
 
 :::note
-Throughout the lab sessions, you will be instructed to configure Emio into specific setups. Simply follow the 
+When using [Emio Labs](../../../Users/EmioLabs/), throughout the lab sessions, you will be instructed to configure Emio into specific setups. Simply follow the 
 provided instructions by clicking on *Set up Emio*. We use colors to refer to the legs and connectors, and numbers to identify the motors.
+:::
+
+## Connecting Emio to Your Computer
+
+<Tabs className="unique-tabs" groupId="operating-systems">
+  <TabItem value="linux" label="Linux" default>
+
+     On Linux, serial ports require specific permissions to be accessed. By default, only the `root` user can access `/dev/ttyUSB*`. Here are two solutions to grant access to serial ports and pilot the real robot:
+
+          <Tabs className="unique-tabs" groupId="serial-ports">
+               <TabItem value="temporary" label="Temporary" default>
+                    Run the following command to grant read/write permissions:
+                    ```bash
+                    sudo chmod 777 /dev/ttyUSB0
+                    ```
+                    Note: Replace `ttyUSB0` with the actual port name. You can find it by running `ls /dev/ttyUSB*` or by using SOFA Robotics. This change will revert after reboot or disconnect.
+               </TabItem>
+               <TabItem value="permanent" label="Permanent" default>
+                    Add your user to the `dialout` group to access serial devices without root privileges:
+                    ```bash
+                    sudo usermod -aG dialout $USER
+                    ```
+                    Then log out and log back in (or reboot) for the group changes to take effect. This is the recommended approach.  
+               </TabItem>
+          </Tabs>
+
+  </TabItem>
+  <TabItem value="windows" label="Windows" default>
+
+       Depending on your version of Windows, you may need to install the [FTDI drivers](https://ftdichip.com/drivers/vcp-drivers/) to pilot the robot. This is typically necessary if, upon connecting the robot to your computer, you encounter the following error message:  
+       `[ERROR] No serial port found with manufacturer = FTDI`.  
+       Installing the drivers should resolve this issue.
+  </TabItem>
+</Tabs>
+
+You will find a USB cable in the drawer to connect the robot to your computer. The robot also has a power supply and a switch.
+To connect Emio to your computer:
+1. Plug the USB cable into the USB port of Emio,
+2. Connect the other end of the USB cable to your computer,
+3. Plug the power supply into the power port of Emio,
+4. Turn on the switch to power the robot.
+
+<div style={{display: "flex"}}>
+    <div>
+        <img className="centered" src={emio_connections} width="30%" alt="The connection panel on the side of Emio"/>
+        <figcaption>(1) USB connection. (2) Power connection. (3) Switch to power the robot.</figcaption>
+    </div>
+</div>
+
+:::note
+To pilot Emio, you have two options: 
+1. You can use [Emio Labs](../../../Users/EmioLabs/), which provides an intuitive interface to launch SOFA Robotics and run simulations to solve Emio's inverse kinematics and control the robot's end-effector.
+2. Or you can use the [Emio API](../../../Developers/emio-api/), which allows you to pilot the motors of Emio programmatically using Python.  
+
+You can find more information about these two options in the following sections.
 :::
 
 ## Calibrating the Camera

--- a/versioned_docs/version-v25.12/Users/EmioLabs/emio-labs-user-manual.md
+++ b/versioned_docs/version-v25.12/Users/EmioLabs/emio-labs-user-manual.md
@@ -39,8 +39,6 @@ Ensure your system meets the following minimum requirements:
   <TabItem value="linux" label="Linux" default>
        :::important[requirements]
        - To use the portable `.AppImage`, install libfuse2: `sudo apt install libfuse2`
-
-       - When trying to connect the real robot, if you get a `[Errno 13] Permission denied: '/dev/ttyUSB0'` message. Run the following command in terminal: `sudo chmod 777 /dev/ttyUSB0`. Make sure that the name of the USB port matches the one from the error message.
        ::: 
        1. **Installer.** If you have downloaded an installer `.deb`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
        2. **Portable.** If you have downloaded a portable `.AppImage`, untar the file, the **Emio Labs** application is the resulting executable file.   
@@ -49,10 +47,6 @@ Ensure your system meets the following minimum requirements:
   <TabItem value="windows" label="Windows">
        :::important[requirements]
        - All formats require [Microsoft Visual C++ 2022 Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) to be installed.
-
-       - Depending on your version of Windows, you may need to install the [FTDI drivers](https://ftdichip.com/drivers/vcp-drivers/) to pilot the robot. This is typically necessary if, upon connecting the robot to your computer, you encounter the following error message:  
-       `[ERROR] No serial port found with manufacturer = FTDI`.  
-       Installing the drivers should resolve this issue.
        :::   
 
        1. **Installer.** If you have downloaded an installer `.msi`, run it and follow the on-screen instructions. When the installation is completed, simply search for the **Emio Labs** application on your computer, as you would do with any other software.
@@ -73,6 +67,8 @@ Ensure your system meets the following minimum requirements:
        To launch Emio Labs on MacOS, please refer to the [section below](#running-emio-labs-on-macos) 
   </TabItem>
 </Tabs>
+
+Check [Getting Starting with Emio](../../Users/Emio/getting-started-with-emio.md) for instructions on how to connect Emio to your computer and pilot the real robot.
 
 ### Running Emio Labs on MacOS
 :::warning

--- a/versioned_docs/version-v25.12/Users/EmioLabs/emio-labs-user-manual.md
+++ b/versioned_docs/version-v25.12/Users/EmioLabs/emio-labs-user-manual.md
@@ -64,7 +64,7 @@ Ensure your system meets the following minimum requirements:
        1. **Installer.** If you have downloaded an installer `.dmg`, run it and follow the on-screen instructions.
        2. **Portable.** If you have downloaded the `.zip`, double-click the file to create a `.app` file.
 
-       To launch Emio Labs on MacOS, please refer to the [section below](#running-emio-labs-on-macos) 
+       To launch Emio Labs on MacOS, please refer to the [section below](#running-emio-labs-on-macos). 
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Solves [this issue](https://github.com/SofaComplianceRobotics/EmioLabs/issues/62): add a doc to permanently enable robot connection on Ubuntu (avoid chmod 777 usb).

In this PR:
- Adds the instruction to permanently enable robot connection on Linux
- Reorganizes instructions: distinguishes installation instructions for Emio Labs and piloting Emio 
- Explains the two options to pilot the real device