### PR TITLE
Adds fetch for dynamixel motors API documentation and improve TOC style

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,14 @@ jobs:
           out-file-path: 'docs/Developers'
           fileName: 'emio-sofa-api.md'
 
+      - name: Fetch DynamixelMotors API docs
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: 'SofaComplianceRobotics/DynamixelMotorsAPI'
+          tag: 'release-main'
+          out-file-path: 'docs/Developers'
+          fileName: 'dynamixelmotorsapi-api.md'
+
       - name: Install dependencies
         run: npm ci
       - name: Build website

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -85,6 +85,10 @@ img {
   font-weight: bold;
 }
 
+.table-of-contents>li>a{
+  font-weight: bold;
+}
+
 .menu__link {
   font-weight: normal;
   font-size: normal;


### PR DESCRIPTION
This PR :
- adds a fetch step in the deploy workflow to get the Dynamixel Motors API documentation
- adds a CSS rule to put the first headings of the side table of contents in bold for easier navigation (see screenshot)

<img width="1536" height="584" alt="image" src="https://github.com/user-attachments/assets/7be30288-1f40-4a26-bac2-db2a049a09cd" />
